### PR TITLE
feat: allow passing extra s3cmd flags

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -17,6 +17,7 @@ After the snapshot is created in a temporary directory, `s3cmd` is used to sync 
 * `S3_BUCKET` - S3 bucket to point to
 * `S3_HOST` - S3 endpoint
 * `S3_EXPIRE_DAYS` - Delete files older than this threshold (expired)
+* `S3_TLS_ARGS` - To specify an explicit CA certificate to use or skip the TLS verification
 * `AWS_ACCESS_KEY_ID` - Access key to use to access S3
 * `AWS_SECRET_ACCESS_KEY` - Secret access key to use to access S3
 

--- a/kubernetes/bao-snapshot.sh
+++ b/kubernetes/bao-snapshot.sh
@@ -2,12 +2,7 @@
 
 set -e
 
-# Set default Vault auth path if not provided
-VAULT_AUTH_PATH=${VAULT_AUTH_PATH:-kubernetes}
-
-echo "Using Vault auth path: $VAULT_AUTH_PATH"
-
-# Authenticate with Vault
+# Authenticate with OpenBao
 JWT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
 export JWT
 
@@ -19,11 +14,11 @@ export BAO_TOKEN
 bao operator raft snapshot save /bao-snapshots/bao_"$(date +%F-%H%M)".snapshot
 
 # Upload to S3
-s3cmd put /bao-snapshots/* "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
+s3cmd put /bao-snapshots/* "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" "${S3CMD_EXTRA_FLAG}"
 
 # Remove expired snapshots
 if [ "${S3_EXPIRE_DAYS}" ]; then
-    s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" | while read -r line; do
+    s3cmd ls "${S3_URI}" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" "${S3CMD_EXTRA_FLAG}" | while read -r line; do
         createDate=$(echo "$line" | awk '{print $1" "$2}')
         createDate=$(date -d"$createDate" +%s)
         olderThan=$(date --date @$(($(date +%s) - 86400*S3_EXPIRE_DAYS)) +%s)

--- a/kubernetes/cronjob.yaml
+++ b/kubernetes/cronjob.yaml
@@ -35,6 +35,9 @@ spec:
               # leave empty to retain snapshot files (default)
             - name: S3_EXPIRE_DAYS
               value:
+              # Leave empty to use system trust store, use "--ca-certs=" to specify the path to the CA or "--no-check-certificate" to skip TLS verification
+            - name: S3CMD_EXTRA_FLAG
+              value:
             - name: BAO_AUTH_PATH
               value: kubernetes
             - name: BAO_ROLE


### PR DESCRIPTION
This allows to pass [extra flags to s3cmd ](https://s3tools.org/usage). Useful, for example, to skip the TLS validation or set the region.