### PR TITLE
Add s3cmd extra flag on snapshot deletion

### DIFF
--- a/kubernetes/bao-snapshot.sh
+++ b/kubernetes/bao-snapshot.sh
@@ -25,7 +25,7 @@ if [ "${S3_EXPIRE_DAYS}" ]; then
         if [ "$createDate" -lt "$olderThan" ]; then
             fileName=$(echo "$line" | awk '{print $4}')
             if [ "$fileName" != "" ]; then
-                s3cmd del "$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}"
+                s3cmd del "$fileName" --host="${S3_HOST}" --host-bucket="${S3_BUCKET}" "${S3CMD_EXTRA_FLAG}"
             fi
         fi
     done;


### PR DESCRIPTION
${S3CMD_EXTRA_FLAG} was not used when deleting old snapshots, preventing it to work for some use cases (eg. when custom CAs need to be used through the --ca-certs switch).
This commit just adds the missing option.